### PR TITLE
feat: Fix pasted text cant be read 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ config: {
   hyperSana: {
     illust: true, // イラストを表示するか（デフォルトは true）
     opacity: 0.3, // イラストの不透明度0~1（デフォルトは0.3）
+    overText: false // イラストの上にテキストを表示するか（デフォルトは false）
   },
   // ...
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,13 +13,14 @@ import {
 const defaultOptions = {
   illust: true,
   opacity: 0.6,
+  overText: false,
 }
 
 exports.decorateConfig = (config) => {
   const options = Object.assign({}, defaultOptions, config.hyperSana)
 
   return Object.assign({}, config, {
-    backgroundColor,
+    backgroundColor: options.overText ? backgroundColor : 'transparent',
     foregroundColor,
     borderColor,
     selectionColor,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import {termCSS, css} from './stylesheets'
 import middleware from './middleware'
 import {
+  backgroundColor,
   foregroundColor,
   borderColor,
   selectionColor,
@@ -15,13 +16,10 @@ const defaultOptions = {
 }
 
 exports.decorateConfig = (config) => {
-  const options = Object.assign({},
-    defaultOptions,
-    config.hyperSana
-  )
+  const options = Object.assign({}, defaultOptions, config.hyperSana)
 
   return Object.assign({}, config, {
-    backgroundColor: 'transparent',
+    backgroundColor,
     foregroundColor,
     borderColor,
     selectionColor,

--- a/src/stylesheets/term.js
+++ b/src/stylesheets/term.js
@@ -15,7 +15,7 @@ export default ({illust: show, opacity, overText}) => {
       background-position: right bottom;
       background-repeat: no-repeat;
       opacity: ${opacity};
-      z-index: ${overText ? '1' : '0'};
+      z-index: ${overText ? '1' : 'auto'};
     }
   `
 }

--- a/src/stylesheets/term.js
+++ b/src/stylesheets/term.js
@@ -1,6 +1,6 @@
 import illust from '../images/sana.svg'
 
-export default ({illust: show, opacity}) => {
+export default ({illust: show, opacity, overText}) => {
   return `
     .terms_terms:before {
       content: "";
@@ -15,7 +15,7 @@ export default ({illust: show, opacity}) => {
       background-position: right bottom;
       background-repeat: no-repeat;
       opacity: ${opacity};
-      z-index: 1;
+      z-index: ${overText ? '1' : '0'};
     }
   `
 }

--- a/src/stylesheets/term.js
+++ b/src/stylesheets/term.js
@@ -15,6 +15,7 @@ export default ({illust: show, opacity}) => {
       background-position: right bottom;
       background-repeat: no-repeat;
       opacity: ${opacity};
+      z-index: 1;
     }
   `
 }


### PR DESCRIPTION
issue: #6
![18d6cc139ac4eec27e041cfdc7aecd9f 1](https://user-images.githubusercontent.com/15053874/42819804-8bc4397a-8a0f-11e8-9a8d-e5efd803b65e.png)

これでペーストしたテキストは見れるようになりましたが,もし他への影響等で `'transparent'` しているなどでしたら指摘ください.
